### PR TITLE
PAGOPA-1060 fixing filters adding empty value

### DIFF
--- a/src/pages/views/CreditorInstitutionsView.tsx
+++ b/src/pages/views/CreditorInstitutionsView.tsx
@@ -163,7 +163,12 @@ export default class CreditorInstitutionView extends React.Component<IProps, ISt
     }
 
     handleMod4Change(event: any){
-        this.setState({mod4Filter: event.target.value === "true"});
+        if(event.target.value === ''){
+            this.setState({mod4Filter: undefined});
+        }
+        else{
+            this.setState({mod4Filter: event.target.value});
+        }
     }
 
     handleSearch(){
@@ -426,6 +431,7 @@ export default class CreditorInstitutionView extends React.Component<IProps, ISt
                                                 onChange={(e) => this.handleMod4Change(e)}
                                                 placeholder="Modello 4"
                                                 value={String(this.state.mod4Filter)}>
+                                        <option value="">-</option>
                                         <option value="true">True</option>
                                         <option value="false">False</option>
                                     </Form.Control>

--- a/src/pages/views/PspView.tsx
+++ b/src/pages/views/PspView.tsx
@@ -145,7 +145,7 @@ export default class PspView extends React.Component<IProps, IState> {
 
     handlePaymentModelChange(event: any){
         if (event.target.value === '') {
-            this.setState({paymentModelFilter: undefined})
+            this.setState({paymentModelFilter: undefined});
         }
         else{
             this.setState({paymentModelFilter: event.target.value});

--- a/src/pages/views/PspView.tsx
+++ b/src/pages/views/PspView.tsx
@@ -144,7 +144,12 @@ export default class PspView extends React.Component<IProps, IState> {
     }
 
     handlePaymentModelChange(event: any){
-        this.setState({paymentModelFilter: event.target.value});
+        if (event.target.value === '') {
+            this.setState({paymentModelFilter: undefined})
+        }
+        else{
+            this.setState({paymentModelFilter: event.target.value});
+        }
     }
 
     handleSearch(){
@@ -379,6 +384,7 @@ export default class PspView extends React.Component<IProps, IState> {
                                     <Form.Control as="select" name="filter_payment_model" 
                                                 placeholder="Payment model"
                                                 onChange={(e) => this.handlePaymentModelChange(e)}>
+                                            <option value="">-</option>
                                             <option value="IMMEDIATO">IMMEDIATO</option>
                                             <option value="IMMEDIATO_MULTIBENEFICIARIO">IMMEDIATO_MULTIBENEFICIARIO</option>
                                             <option value="DIFFERITO">DIFFERITO</option>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Fixing the filter in both views. When the pages are loaded, Modello4 in EC view and Modello di Pagamento in PSP view have two selected values, which are not used in the filter when the page is loaded. In order to fix this issue an empty element is added to increase the coherency of the page.
#### Motivation and Context
This fix was required in order to increase the coherency of the filters in the views. 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
This has been tested manually using the h2 profile
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
Before:
![image](https://github.com/pagopa/pagopa-api-config-fe/assets/49512050/e1aad911-8eed-4e4c-8a82-935ec64c54c4)
After: 
<img width="1442" alt="Screenshot 2023-06-26 alle 12 49 16" src="https://github.com/pagopa/pagopa-api-config-fe/assets/49512050/ca21f14e-37fa-48ae-9e10-b9c28a7fcb8a">

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.