### PR TITLE
[PAGOPA-964] fix: set disabled checkbox on read

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-api-config-fe",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "license": "MIT",
   "scripts": {
     "envconfig": "chmod +x envconfig.sh && . ./envconfig.sh",

--- a/src/pages/channels/ChannelView.tsx
+++ b/src/pages/channels/ChannelView.tsx
@@ -866,6 +866,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         label={'PSP Notify Payment'}
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
                                                             </Form.Group>
                                                             <Form.Group controlId="flag_psp_cp"
@@ -879,6 +880,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         label={'Travaso Additional Payment'}
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
 
                                                                 <OverlayTrigger placement="top"
@@ -899,6 +901,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         name="rt_push"
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
                                                             </Form.Group>
 
@@ -913,6 +916,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         name="on_us"
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
                                                             </Form.Group>
 
@@ -927,6 +931,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         name="card_chart"
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
                                                             </Form.Group>
 
@@ -941,6 +946,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         name="recovery"
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
                                                             </Form.Group>
 
@@ -955,6 +961,7 @@ export default class ChannelView extends React.Component<IProps> {
                                                                         name="digital_stamp_brand"
                                                                         onChange={(e) => this.handleChange(e)}
                                                                         readOnly={this.props.readOnly}
+                                                                        disabled={this.props.readOnly}
                                                                 />
                                                             </Form.Group>
                                                         </div>


### PR DESCRIPTION
This PR contains a fix made on Channels detail view that permits to make the checkboxes in read as read-only non-selectable elements. 

#### List of Changes
 - Set checkboxes as disabled in read mode

#### Motivation and Context
This change is made only for aesthetics motivation, it does not add a real enhancement on logic. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/pagopa-api-config-fe/assets/117269497/0cc2ecde-b19e-4630-a5d3-4f7fdbf8aeb3)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.