### PR TITLE
[PAGOPA-1076] Deleting unused "Nuova Password" field 

### DIFF
--- a/src/pages/channels/ChannelView.tsx
+++ b/src/pages/channels/ChannelView.tsx
@@ -547,13 +547,6 @@ export default class ChannelView extends React.Component<IProps> {
                                                                               onChange={(e) => this.handleChange(e)}
                                                                               readOnly={this.props.readOnly}/>
                                                             </Form.Group>
-                                                            <Form.Group controlId="new_password" className="col-md-4">
-                                                                <Form.Label>Nuova Password</Form.Label>
-                                                                <Form.Control name="new_password" placeholder=""
-                                                                              value={this.props.channel.new_password}
-                                                                              onChange={(e) => this.handleChange(e)}
-                                                                              readOnly={this.props.readOnly}/>
-                                                            </Form.Group>
                                                         </div>
 
                                                         <div className={"divider"}></div>

--- a/src/pages/stations/StationView.tsx
+++ b/src/pages/stations/StationView.tsx
@@ -261,18 +261,10 @@ export default class StationView extends React.Component<IProps> {
                                                                 )}
                                                             </Form.Group>
 
-                                                            <Form.Group controlId="password" className="col-md-4">
+                                                            <Form.Group controlId="password" className="col-md-6">
                                                                 <Form.Label>Password</Form.Label>
                                                                 <Form.Control name="password"
                                                                               value={this.props.station.password}
-                                                                              onChange={(e) => this.handleChange(e)}
-                                                                              readOnly={this.props.readOnly}/>
-                                                            </Form.Group>
-
-                                                            <Form.Group controlId="new_password" className="col-md-4">
-                                                                <Form.Label>Nuova Password</Form.Label>
-                                                                <Form.Control name="new_password"
-                                                                              value={this.props.station.new_password}
                                                                               onChange={(e) => this.handleChange(e)}
                                                                               readOnly={this.props.readOnly}/>
                                                             </Form.Group>


### PR DESCRIPTION
This PR contains a fix made on Canali and Stazioni pages in order to remove the fields related to the New password information.

#### List of Changes
 - Removed fields related to new password information

#### Motivation and Context
This change is required in order to permits to delete all references to these column on portal.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):
New view on Channel detail section (similar to Station section). 

From this view:
![image](https://github.com/pagopa/pagopa-api-config-fe/assets/117269497/d00c0922-0613-4e97-9ac6-d5fbc2de5485)
To this view:
![image](https://github.com/pagopa/pagopa-api-config-fe/assets/117269497/a788e07e-689a-4ca6-929e-d8fd6c10aac1)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
